### PR TITLE
Speedup

### DIFF
--- a/papers/H0_I/Analysis/CRACO/Cubes/craco_full_cube_v2.json
+++ b/papers/H0_I/Analysis/CRACO/Cubes/craco_full_cube_v2.json
@@ -1,0 +1,64 @@
+{
+    "state": {
+        "energy": {
+            "luminosity_function": 2
+        },
+        "FRBdemo": {
+            "alpha_method": 1
+        },
+        "cosmo": {
+            "fix_Omega_b_h2": true
+        }
+    },
+    "cube": {
+        "parameter_order": ["lC", "sfr_n", "alpha", "lEmax", "gamma", "lmean", "lsigma", "H0"]
+    },
+    "lEmax": {
+        "DC": "energy",
+        "min": 40.9, 
+        "max": 42.0, 
+        "n": 23
+    },
+    "H0": {
+        "DC": "cosmo",
+        "min": 60.0, 
+        "max": 75.0, 
+        "n": 16
+    },
+    "alpha": {
+        "DC": "energy",
+        "min": 0.0, 
+        "max": 2.0, 
+        "n": 5
+    },
+    "gamma": {
+        "DC": "energy",
+        "min": -0.6, 
+        "max": -1.5, 
+        "n": 10
+    },
+    "sfr_n": {
+        "DC": "FRBdemo",
+        "min": 0.0, 
+        "max": 3.0, 
+        "n": 20
+    },
+    "lmean": {
+        "DC": "host",
+        "min": 1.7, 
+        "max": 2.5, 
+        "n": 10
+    },
+    "lsigma": {
+        "DC": "host",
+        "min": 0.2, 
+        "max": 0.9, 
+        "n": 10
+    },
+    "lC": {
+        "DC": "FRBdemo",
+        "min": -0.911, 
+        "max": -0.911, 
+        "n": -1
+    }
+}

--- a/zdm/analyze_cube.py
+++ b/zdm/analyze_cube.py
@@ -219,6 +219,9 @@ def get_bayesian_data(lls:np.ndarray,
             #lls=data[set1,llindex]
             lls=origlls[tuple(big_slice)].flatten()
             
+            # ignores all values of 0, which is what missing data is
+            ignore=np.where(lls == 0.)[0]
+            lls[ignore]=-99999
             
             # selects all fits that are close to the peak (i.e. percentage within 0.1%)
             try:

--- a/zdm/iteration.py
+++ b/zdm/iteration.py
@@ -779,7 +779,7 @@ def missing_cube_likelihoods(grids,surveys,todo,outfile,norm=True,psnr=True,star
         
         ### calculates actual values at each point ###
         
-        C,llC,lltot=minimise_const_only(pset,grids,surveys)
+        C,llC=minimise_const_only(pset,grids,surveys)
         pset[7]=C
         
         # for the minimised parameters, set the values
@@ -962,7 +962,7 @@ def cube_likelihoods(grids:list,surveys:list,
                 #    pset[s]=C_p[s]
             
             if const_only:
-                C,llC,lltot=minimise_const_only(
+                C,llC=minimise_const_only(
                     vparams,grids,surveys)
                 vparams['lC']=C
 
@@ -1822,24 +1822,6 @@ def minimise_const_only(vparams:dict,grids:list,surveys:list,
             grids[j].update(vparams, 
                         prev_grid=grids[j-1] if (
                             j > 0 and use_prev_grid) else None)
-        # Calculate
-        if s.nD==1:
-            lls[j] = calc_likelihoods_1D(grids[j],s,
-                    norm=True,psnr=True,Pn=False) #excludes Pn term
-        elif s.nD==2:
-            lls[j] = calc_likelihoods_2D(grids[j],s,
-                    norm=True,psnr=True,Pn=False, verbose=Verbose) #excludes Pn term
-        elif s.nD==3: # mixture of localised and un-localised
-            lls[j] = calc_likelihoods_1D(grids[j],s,
-                    norm=True,psnr=True,Pn=False) #excludes Pn term
-            lls[j] += calc_likelihoods_2D(grids[j],s,
-                    norm=True,psnr=True,Pn=False) #excludes Pn term
-        else:
-            raise ValueError("Unknown code ",s.nD," for dimensions of survey")
-        
-        if Verbose:
-            print(f"survey={grids[j].survey.name}, lls={lls[j]}")
-        
         ### Assesses total number of FRBs ###
         if s.TOBS is not None:
             r=np.sum(grids[j].rates)*s.TOBS
@@ -1847,8 +1829,7 @@ def minimise_const_only(vparams:dict,grids:list,surveys:list,
             o=s.NORM_FRB
             rs.append(r)
             os.append(o)
-    if Verbose:
-        print("Total sum of ll w/o const is ",np.sum(lls[j]))
+    
     data=np.array([rs,os])
     ratios=np.log10(data[1,:]/data[0,:])
     bounds=(np.min(ratios),np.max(ratios))
@@ -1863,9 +1844,7 @@ def minimise_const_only(vparams:dict,grids:list,surveys:list,
     #newC=vparams['lC']+float(dC)
     newC = grids[j].state.FRBdemo.lC + float(dC)
     llC=-minus_poisson_ps(dC,data)
-    lltot=llC+np.sum(lls)
-    #embed(header='1840 of it')
-    return newC,llC,lltot
+    return newC,llC
     
     
 def set_orders(parameter_order:list, PARAMS:list):

--- a/zdm/tests/Performance/test_update_performance.py
+++ b/zdm/tests/Performance/test_update_performance.py
@@ -37,7 +37,7 @@ import numpy as np
 def main(likelihoods=True,detail=0,verbose=True):
     
     ############## Load up ##############
-    input_dict=io.process_jfile('../../../papers/H0_I/Analysis/Cubes/craco_H0_Emax_state.json')
+    input_dict=io.process_jfile('../../../papers/H0_I/Analysis/CRACO/Cubes/craco_H0_Emax_state.json')
 
     # Deconstruct the input_dict
     state_dict, cube_dict, vparam_dict = it.parse_input_dict(input_dict)
@@ -94,8 +94,8 @@ def main(likelihoods=True,detail=0,verbose=True):
                 psnr=True
                 
                 # these two options should give identical answers
-                C1,llC,lltot=it.minimise_const_only(None,grids,surveys,use_prev_grid=False)
-                C2,llC,lltot=it.minimise_const_only(vparams,grids,surveys,use_prev_grid=False)
+                C1,llC=it.minimise_const_only(None,grids,surveys,use_prev_grid=False)
+                C2,llC=it.minimise_const_only(vparams,grids,surveys,use_prev_grid=False)
                 if np.abs((C2-C1)/(C2+C1)) > 1e-3:
                     print("Two minimisations give different values of the constant! ",C1," and ",C2)
                 t3=time.time() #times the minimisation routine


### PR DESCRIPTION
Very small set of changes that removes the likelihood calculation from the minimise constant only. I have tested this with the routine zdm/tests/Performance/test_update_performance.py and this works nicely. But since we want to use it asap (will save maybe... 30-40% of time?) I've made this a pull request rather than a simple push.