### PR TITLE
Updated differential burst fractions in energetics.py to be 0.0 below…

### DIFF
--- a/zdm/energetics.py
+++ b/zdm/energetics.py
@@ -185,7 +185,7 @@ def vector_diff_power_law(Eth,*params):
     
     low=np.where(Eth < Emin)[0]
     if len(low) > 0:
-        result[low]=1.  # This was 0 and I think it was wrong -- JXP
+        result[low]=0.  
     high=np.where(Eth > Emax)[0]
     if len(high) > 0:
         result[high]=0.
@@ -346,6 +346,6 @@ def vector_diff_gamma(Eth,*params):
     result= (Eth/Emax)**(gamma-1) * np.exp(-Eth/Emax) / norm
     
     low= Eth < Emin
-    result[low]=1.  # This was 0 and I think it was wrong
+    result[low]=0.
     
     return result


### PR DESCRIPTION
… Emin, not 1.0

@profxj had changed these from 0.0 to 1.0 below Emin, maybe to be consistent with the cumulative burst fractions (?). In the case of cumulative burst fractions, 1 is correct because the total number of bursts observed with energy greater than Eth for Eth<Emin is always one. Whereas, for the differential case, I think 0.0 is correct as the differential functions are calculating the change, as a function of energy, in the cumulative number of bursts observed above some Eth, for Eth < Emin, which is zero, because for all Eth < Emin the cumulative number is 1.